### PR TITLE
Fix getMonotonicTime() on osx

### DIFF
--- a/src/criterion/timer.nim
+++ b/src/criterion/timer.nim
@@ -21,9 +21,9 @@ elif defined(macosx):
     MachTimebaseInfoData {.pure, final,
         importc: "mach_timebase_info_data_t",
         header: "<mach/mach_time.h>".} = object
-      numer, denom: int32
+      numer, denom: uint32
 
-  proc mach_absolute_time(): int64 {.importc, header: "<mach/mach.h>".}
+  proc mach_absolute_time(): uint64 {.importc, header: "<mach/mach_time.h>".}
   proc mach_timebase_info(info: var MachTimebaseInfoData) {.importc,
     header: "<mach/mach_time.h>".}
 


### PR DESCRIPTION
when `<mach/mach_time.h>` is not imported `mach_absolute_time` returns weird results

this leads for unpredictable behavior, ex:
https://github.com/LemonBoy/criterion.nim/blob/6d9ddb4b648a486944d8befef468e8c28d905a89/src/criterion/impl.nim#L32-L37
```
rtFinish: -2147483622.0
rtStart: 2147483644.0
```